### PR TITLE
fix(awesome): Specs are not including the start date (#23)

### DIFF
--- a/src/awesome.js
+++ b/src/awesome.js
@@ -21,6 +21,7 @@ const saveFile = (fullPath, fileName, json) => {
 class AwesomeReport {
   static getReport(config) {
     let currentSuite;
+    let currentTest;
     let json;
 
     return {
@@ -41,11 +42,10 @@ class AwesomeReport {
         currentSuite = node;
       },
       specStarted: (result) => {
-        // eslint-disable-next-line no-param-reassign
-        result.start = new Date();
+        currentTest = Object.assign({}, result, { start: new Date() });
       },
       specDone: (result) => {
-        const node = Object.assign({}, result, { end: new Date() });
+        const node = Object.assign({}, result, currentTest, { end: new Date() });
 
         currentSuite.tests.push(node);
       },

--- a/test/awesome.spec.js
+++ b/test/awesome.spec.js
@@ -83,23 +83,27 @@ describe('Given a jasmine execution', () => {
             assert.deepEqual(testResult, objectStub.getCall(2).args[1]);
             assert.deepEqual({
               end: jasmineStartDate
-            }, objectStub.getCall(2).args[2]);
+            }, objectStub.getCall(2).args[3]);
           });
         });
       });
-    });
 
-    describe('when start a test', () => {
-      const testStartDate = new Date('2017-08-29T21:48:13.023Z');
-      const test = {};
+      describe('when start a test', () => {
+        const testStartDate = new Date('2017-08-29T21:48:13.023Z');
+        const test = {
 
-      before(() => {
-        sandboxInstance.useFakeTimers(testStartDate);
-        report.specStarted(test);
-      });
+        };
 
-      it('then should be start property', () => {
-        assert.deepEqual(testStartDate, test.start);
+        before(() => {
+          sandboxInstance.useFakeTimers(testStartDate);
+          report.specStarted(test);
+        });
+
+        it('then should be start property', () => {
+          assert.deepEqual(objectStub.getCall(0).args[0], {});
+          assert.deepEqual(objectStub.getCall(0).args[1], startedParam);
+          assert.deepEqual(objectStub.getCall(0).args[2].start, testStartDate);
+        });
       });
     });
   });


### PR DESCRIPTION
add a currentSpec object to be able to merge the whole object when the event for specDone is called